### PR TITLE
chore: increase aws qps frequency

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -23,7 +23,7 @@ const (
 	// resources. Cache hits enable faster provisioning and reduced API load on
 	// AWS APIs, which can have a serious impact on performance and scalability.
 	// DO NOT CHANGE THIS VALUE WITHOUT DUE CONSIDERATION
-	DefaultTTL = time.Minute
+	DefaultTTL = 5 * time.Minute
 	// UnavailableOfferingsTTL is the time before offerings that were marked as unavailable
 	// are removed from the cache and are available for launch again
 	UnavailableOfferingsTTL = 3 * time.Minute


### PR DESCRIPTION
cache is used to cache aws resources like ami, subnets which we don't change frequently.
https://github.com/smartnews/karpenter-provider-aws/blob/e4faadc9b54bb47e837cc0f30d49a15bf306901d/pkg/operator/operator.go#L146

increase it because we already reached the API limit.

```
{"level":"ERROR","time":"2024-03-13T05:10:33.985Z","logger":"controller","message":"Reconciler error","commit":"ec1ade0","controller":"nodeclaim.disruption","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"memory-arm-ondemand-small-ntf92"},"namespace":"","name":"memory-arm-ondemand-small-ntf92","reconcileID":"f7fc5d20-7354-4acc-bed2-fadda7a0596b","error":"getting drift, calculating ami drift, getting amis, describing images, RequestLimitExceeded: Request limit exceeded.\n\tstatus code: 503, request id: c2f62c5e-e818-46fe-a140-6fdf2ddfc911"}
```