### PR TITLE
chore: improve spot interruption handling

### DIFF
--- a/pkg/controllers/interruption/controller.go
+++ b/pkg/controllers/interruption/controller.go
@@ -201,6 +201,10 @@ func (c *Controller) handleNodeClaim(ctx context.Context, msg messages.Message, 
 		// try to create a new nodeclaim immediately but ignore error if it fails
 		if err := c.createNodeClaim(ctx, nodeClaim); err != nil {
 			logging.FromContext(ctx).Errorf("[interruption handling]failed to create a new nodeclaim, %v", err)
+		} else {
+			logging.FromContext(ctx).Infof("Created new nodeclaim due to spot interruption")
+			// wait for the node provisioning before draining
+			time.Sleep(60 * time.Second)
 		}
 	}
 	if action != NoAction {


### PR DESCRIPTION
if the new nodeclaim is created successfully, then no need to drain right away.